### PR TITLE
Add 'Contributing' Page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+src/web/persistent.store

--- a/src/web/messages.pot
+++ b/src/web/messages.pot
@@ -8,14 +8,113 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-01-22 21:54+0000\n"
+"POT-Creation-Date: 2024-01-24 10:50+1300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.14.0\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: templates/contributing.html:4
+msgid "Contributing to Subsurface"
+msgstr ""
+
+#: templates/contributing.html:14
+msgid "Contributing"
+msgstr ""
+
+#: templates/contributing.html:16
+msgid ""
+"Subsurface is a community driven open source project. It is available "
+"free of charge to everybody, and nobody gets paid to work on it. If you "
+"like it and would like to contribute back there are a number of different"
+" ways you can do so:"
+msgstr ""
+
+#: templates/contributing.html:18
+msgid "By Writing Code"
+msgstr ""
+
+#: templates/contributing.html:20
+#, python-format
+msgid ""
+"If you are a software developer (of any experience level), your help with"
+" maintaining and extending Subsurface will be greatly appreciated. Have a"
+" look at <a %(link)s>the code contribution page on GitHub</a> to see how "
+"you can get started."
+msgstr ""
+
+#: templates/contributing.html:23
+msgid "By Testing"
+msgstr ""
+
+#: templates/contributing.html:25
+#, python-format
+msgid ""
+"If you would like to work closely with our developers and give them a "
+"hand in testing the latest features and bugfixes, please head over to <a "
+"%(link)s>the code contribution page on GitHub</a> to find out how to join"
+" the community. We especially need people running Windows and Mac (as the"
+" majority of the active developers are Linux people)."
+msgstr ""
+
+#: templates/contributing.html:28
+msgid "By Writing Documentation"
+msgstr ""
+
+#: templates/contributing.html:30
+#, python-format
+msgid ""
+"If you are good with words you can help us by writing, reviewing, and "
+"improving documentation and articles for our website. To get started "
+"please head over to <a %(link)s>the code contribution page on GitHub</a> "
+"to find out how join the community."
+msgstr ""
+
+#: templates/contributing.html:33
+msgid "By Translating Subsurface"
+msgstr ""
+
+#: templates/contributing.html:35
+#, python-format
+msgid ""
+"If you are a non-English-speaker, and would like to be able to use "
+"Subsurface in your native language, you can help make this happen by "
+"supporting us as a translator. As our translations are centrally handled "
+"at <a %(transifex)s>Transifex</a> - please sign up for an account there "
+"and then request to join the <a %(transifex_subsurface)s>Subsurface "
+"Team</a>."
+msgstr ""
+
+#: templates/contributing.html:39
+msgid "By Helping Other Users"
+msgstr ""
+
+#: templates/contributing.html:41
+#, python-format
+msgid ""
+"We want to make Subsurface as friendly and welcoming to new users as "
+"possible. If you are a seasoned user of Subsurface please join our <a "
+"%(link)s>User Forum</a> and provide helpful responses to the questions "
+"from new users."
+msgstr ""
+
+#: templates/contributing.html:44
+msgid "By Supporting Us Financially"
+msgstr ""
+
+#: templates/contributing.html:46
+#, python-format
+msgid ""
+"Running Subsurface costs money. This is particularly the case for the "
+"free cloud based synchronisation of dive logs that is built into "
+"Subsurface. The principal maintainer of Subsurface and of our "
+"infrastructure appreciates donations to help cover these expenses. If you"
+" would like to help with this you can do so through <a %(link)s>Dirk's "
+"Ko-fi page</a>."
+msgstr ""
 
 #: templates/current-release.html:14
 #, python-format

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -119,5 +119,10 @@ def user_forum():
     return render_template("user-forum.html", request=request)
 
 
+@app.get("/contributing")
+def contributing():
+    return render_template("contributing.html", request=request)
+
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port="8002", debug=True)

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -49,7 +49,7 @@
                     <ul class="nav nav-pills flex-md-column flex-row flex-nowrap flex-shrink-1 flex-md-grow-0 flex-grow-1 mb-md-auto mb-0 justify-content-center align-items-center align-items-md-start"
                         id="menu">
                         <li class="nav-item">
-                            <a href="#" class="nav-link link-secondary px-md-0 px-2">
+                            <a href="/" class="nav-link link-secondary px-md-0 px-2">
                                 <i class="fa fa-fw fa-home"></i><span class="ms-1 d-none d-md-inline">Home</span>
                             </a>
                         </li>
@@ -91,6 +91,12 @@
                             <a href="https://subsurface-divelog.org/misc/privacy-policy"
                                class="nav-link link-secondary px-md-0 px-2"><i class="fa fa-fw fa-user-circle"></i><span
                                       class="ms-1 d-none d-md-inline">Privacy Policy</span></a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="/contributing" class="nav-link link-secondary px-md-0 px-2">
+                                <i class="fa fa-fw fa-recycle"></i><span
+                                      class=" ms-1 d-none d-md-inline">Contributing</span>
+                            </a>
                         </li>
                         <li class="nav-item">
                             <a href="https://ko-fi.com/dirkhh" target="_blank"

--- a/src/web/templates/contributing.html
+++ b/src/web/templates/contributing.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% set active_page = "contributing" %}
+
+{% block title %}{{ _("Contributing to Subsurface") }}{% endblock %}
+{% block head %}
+{{ super() }}
+
+{% endblock %}
+
+{% block page_content %}
+<div class="container">
+  <div class="row g-5">
+    <div class="col-12">
+        <h1 class="text-primary">{{ _("Contributing") }}</h1>
+      <p>
+        {{ _("Subsurface is a community driven open source project. It is available free of charge to everybody, and nobody gets paid to work on it. If you like it and would like to contribute back there are a number of different ways you can do so:") }}
+      </p>
+      <h4>{{ _("By Writing Code") }}</h4>
+      <p>
+        {{ _("If you are a software developer (of any experience level), your help with maintaining and extending Subsurface will be greatly appreciated. Have a look at <a %(link)s>the code contribution page on GitHub</a> to see how you can get started.",
+	link="href=https://github.com/subsurface/subsurface/blob/master/CONTRIBUTING.md") }}
+      </p>
+      <h4>{{ _("By Testing") }}</h4>
+      <p>
+        {{ _("If you would like to work closely with our developers and give them a hand in testing the latest features and bugfixes, please head over to <a %(link)s>the code contribution page on GitHub</a> to find out how to join the community. We especially need people running Windows and Mac (as the majority of the active developers are Linux people).",
+	link="href=https://github.com/subsurface/subsurface/blob/master/CONTRIBUTING.md") }}
+      </p>
+      <h4>{{ _("By Writing Documentation") }}</h4>
+      <p>
+        {{ _("If you are good with words you can help us by writing, reviewing, and improving documentation and articles for our website. To get started please head over to <a %(link)s>the code contribution page on GitHub</a> to find out how join the community.",
+	link="href=https://github.com/subsurface/subsurface/blob/master/CONTRIBUTING.md") }}
+      </p>
+      <h4>{{ _("By Translating Subsurface") }}</h4>
+      <p>
+      {{ _("If you are a non-English-speaker, and would like to be able to use Subsurface in your native language, you can help make this happen by supporting us as a translator. As our translations are centrally handled at <a %(transifex)s>Transifex</a> - please sign up for an account there and then request to join the <a %(transifex_subsurface)s>Subsurface Team</a>.",
+      transifex="href=https://www.transifex.com/",
+      transifex_subsurface="href=https://www.transifex.com/projects/p/subsurface/") }}
+      </p>
+      <h4>{{ _("By Helping Other Users") }}</h4>
+      <p>
+      {{ _("We want to make Subsurface as friendly and welcoming to new users as possible. If you are a seasoned user of Subsurface please join our <a %(link)s>User Forum</a> and provide helpful responses to the questions from new users.",
+        link="href=/user-forum") }}
+      </p>
+      <h4>{{ _("By Supporting Us Financially") }}</h4>
+      <p>
+      {{ _("Running Subsurface costs money. This is particularly the case for the free cloud based synchronisation of dive logs that is built into Subsurface. The principal maintainer of Subsurface and of our infrastructure appreciates donations to help cover these expenses. If you would like to help with this you can do so through <a %(link)s>Dirk's Ko-fi page</a>.",
+        link="href=https://ko-fi.com/dirkhh") }}
+      </p>
+    </div>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Also fixed the back-link to home in the navbar, and added a deployment artifact to .gitignore.

This is a first version of what I have in mind as a 'contributing' page, which then can be linked from within the application. The idea is to make more users aware of how Subsurface is operating, and give them a quick way to see the various ways they can contribute based on their skills and passions.

I like the new framework, it seems to be relatively painless to work with.