### PR TITLE
[home] Fix subtitle

### DIFF
--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -14,7 +14,7 @@
         <div class="col-auto">
           <h1 class="display-3 ssrf">Subsurface</h1>
           <p class="lead col-auto">
-            {{ _("The free, open-source cross-platform dive log software.") }}.
+            {{ _("The free, open-source cross-platform dive log software.") }}
           </p>
         </div>
         <div class="col-auto mt-4 {% if 'Windows' not in request.user_agent.string %}d-none{% endif %}">


### PR DESCRIPTION
Subtitle in home page is showing two ending points.
Remove the one outside the string to avoid translating it again.