### PR TITLE
Wording: Rename the 'Contributing' Page to 'Contribute'.

### DIFF
--- a/src/web/server.py
+++ b/src/web/server.py
@@ -184,9 +184,9 @@ def user_forum():
     return render_template("user-forum.html", request=request)
 
 
-@app.get("/contributing/")
-def contributing():
-    return render_template("contributing.html", request=request)
+@app.get("/contribute/")
+def contribute():
+    return render_template("contribute.html", request=request)
 
 
 @app.get("/bugtracker/")

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -101,10 +101,10 @@
                                       class="ms-1 d-none d-md-inline">{{ _("Privacy Policy") }}</span></a>
                         </li>
                         <li class="nav-item">
-                            <a href="/contributing"
-                               class="nav-link {% if request.endpoint == 'contributing' %}ssrf{% else %}link-secondary{% endif %} px-md-0 px-2">
+                            <a href="/contribute"
+                               class="nav-link {% if request.endpoint == 'contribute' %}ssrf{% else %}link-secondary{% endif %} px-md-0 px-2">
                                 <i class="fa fa-fw fa-recycle"></i><span
-                                      class=" ms-1 d-none d-md-inline">{{ _("Contributing") }}</span>
+                                      class=" ms-1 d-none d-md-inline">{{ _("Contribute") }}</span>
                             </a>
                         </li>
                         <li class="nav-item">

--- a/src/web/templates/contribute.html
+++ b/src/web/templates/contribute.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ _("Contributing to Subsurface") }}{% endblock %}
+{% block title %}{{ _("Contribute to Subsurface") }}{% endblock %}
 {% block head %}
 {{ super() }}
 
@@ -10,28 +10,28 @@
 <div class="container">
   <div class="row g-5">
     <div class="col-12">
-      <h1 class="ssrf">{{ _("Contributing") }}</h1>
+      <h1 class="ssrf">{{ _("Contribute") }}</h1>
       <p>
         {{ _("Subsurface is a community driven open source project. It is available free of charge to everybody, and nobody gets paid to work on it. If you like it and would like to contribute back there are a number of different ways you can do so:") }}
       </p>
       <h4>{{ _("By Writing Code") }}</h4>
       <p>
-        {{ _("If you are a software developer (of any experience level), your help with maintaining and extending Subsurface will be greatly appreciated. Have a look at <a %(link)s>the code contribution page on GitHub</a> to see how you can get started.",
+        {{ _("If you are a software developer (of any experience level), your help with maintaining and extending Subsurface will be greatly appreciated. Have a look at our <a %(link)s>code contribution page on GitHub</a> to see how you can get started.",
         link="href=https://github.com/subsurface/subsurface/blob/master/CONTRIBUTING.md") }}
       </p>
       <h4>{{ _("By Testing") }}</h4>
       <p>
-        {{ _("If you would like to work closely with our developers and give them a hand in testing the latest features and bugfixes, please head over to the code contribution page on GitHub to find out <a %(link)s>how to join the community</a>. We especially need people running Windows and Mac (as the majority of the active developers are Linux people).",
+        {{ _("If you would like to work closely with our developers and give them a hand in testing the latest features and bugfixes, please head over to our code contribution page on GitHub to find out <a %(link)s>how to join the community</a>. We especially need people running Windows and Mac (as the majority of the active developers are Linux people).",
         link="href=https://github.com/subsurface/subsurface/blob/master/CONTRIBUTING.md#joining-the-subsurface-contributors-community") }}
       </p>
       <h4>{{ _("By Writing Documentation") }}</h4>
       <p>
-        {{ _("If you are good with words you can help us by writing, reviewing, and improving documentation and articles for our website. To get started please head over to the code contribution page on GitHub to find out <a %(link)s>how to join the community</a>.",
+        {{ _("If you are good with words you can help us by writing, reviewing, and improving documentation and articles for our website. To get started please head over to our code contribution page on GitHub to find out <a %(link)s>how to join the community</a>.",
         link="href=https://github.com/subsurface/subsurface/blob/master/CONTRIBUTING.md#joining-the-subsurface-contributors-community") }}
       </p>
       <h4>{{ _("By Improving the User Experience") }}</h4>
       <p>
-        {{ _("If you like to obsess over usability and user experience, and ideally have some experience in UX and / or web design, we can always use help with improving the user experience and visual design of Subsurface and of our website. To get started please head over to the code contribution page on GitHub to find out <a %(link)s>how to join the community</a>.",
+        {{ _("If you like to obsess over usability and user experience, and ideally have some experience in UX and / or web design, we can always use help with improving the user experience and visual design of Subsurface and of our website. To get started please head over to our code contribution page on GitHub to find out <a %(link)s>how to join the community</a>.",
         link="href=https://github.com/subsurface/subsurface/blob/master/CONTRIBUTING.md#joining-the-subsurface-contributors-community") }}
       </p>
       <h4>{{ _("By Translating Subsurface") }}</h4>

--- a/src/web/templates/faq.html
+++ b/src/web/templates/faq.html
@@ -64,7 +64,7 @@
                 {{ _("Subsurface is open source software. It's free to use. It's written by a group of enthusiasts who do this in their spare time - including providing the Subsurface Cloud storage and all the other infrastructure. Please understand that this also means that they will respond to your requests when they have time, and they generally don't appreciate being treated like the support team of a commercial vendor. If you'd like a commercial dive log program, there are plenty others to choose from.") }}
               </p>
               <p>
-                {{ _("If you would like to contribute and help, there are many ways to do so. Please take a look at our <a %(contributing)s>contributing</a> page.", contributing="href=/contributing/") }}
+                {{ _("If you would like to contribute and help, there are many ways to do so. Our '<a %(contribute)s>Contribute</a>' page lists a few options and provides information on how to get started.", contribute="href=/contribute/") }}
               </p>
             </div>
           </div>
@@ -82,7 +82,7 @@
                 {{ _("As mentioned in the previous question, Subsurface is written and maintained by volunteers. It also has several ten thousand users. The current feature set aims to find a reasonable balance between a user experience that is easy to understand, and addressing the most commonly requested features. New features often get rejected if none of the existing developers feel strongly that they would make a significant difference to the majority of our users.") }}
               </p>
               <p>
-                {{ _("You are of course invited and encouraged to provide an implementation for your desired new feature. Please take a look at our <a %(contributing)s>contributing</a> page.", contributing="href=/contributing/") }}
+                {{ _("You are of course invited and encouraged to provide an implementation for your desired new feature. Please take a look at our <a %(code_contribution)s>code contribution page on GitHub</a>.", code_contribution="href=https://github.com/subsurface/subsurface/blob/master/CONTRIBUTING.md") }}
               </p>
             </div>
           </div>
@@ -325,7 +325,7 @@
                 {{ _("Adding support for another Linux distribution is generally a lot of work and given the tiny user numbers not likely to happen. But please, talk to us if you think there is a distribution that we should add instead of the ones that we currently support.") }}
               </p>
               <p>
-                {{ _("If you would like to contribute and help, this is a perfect opportunity to do so. Please take a look at our <a %(contributing)s>contributing</a> page.", contributing="href=/contributing/") }}
+	      {{ _("If you would like to contribute and help, this is a perfect opportunity to do so. Please take a look at our <a %(code_contribution)s>code contribution page on GitHub</a>.", code_contribution="href=https://github.com/subsurface/subsurface/blob/master/CONTRIBUTING.md") }}
               </p>
             </div>
           </div>
@@ -344,7 +344,7 @@
                 {{ _("Yes, generally this is pretty easy (assuming you are somewhat familiar with C/C++ development under Linux). The <code>INSTALL</code> file in the source directory should get you started. Reach out to the developers if you need help beyond that (because likely that means we need to update the <code>INSTALL</code> file...).") }}
               </p>
               <p>
-                {{ _("If you would like to contribute and help, this is a perfect opportunity to do so. Please take a look at our <a %(contributing)s>contributing</a> page.", contributing="href=/contributing/") }}
+	      {{ _("If you would like to contribute and help, this is a perfect opportunity to do so. Please take a look at our <a %(code_contribution)s>code contribution page on GitHub</a>.", code_contribution="href=https://github.com/subsurface/subsurface/blob/master/CONTRIBUTING.md") }}
               </p>
             </div>
           </div>
@@ -664,7 +664,7 @@
                 {{ _("A good starting point is often to send us a libdivecomputer log and dump (you can pick those in the dive computer download dialog) when connecting to the dive computer using a similar existing model (if possible). But generally it might make the most sense to first reach out in order to avoid wasting your time.") }}
               </p>
               <p>
-                {{ _("If you would like to contribute and help, there are many ways to do so. Please take a look at our <a %(contributing)s>contributing</a> page.", contributing="href=/contributing/") }}
+                {{ _("If you would like to contribute and help, there are many ways to do so. Please take a look at our '<a %(contribute)s>Contribute</a>' page.", contribute="href=/contribute/") }}
               </p>
             </div>
           </div>


### PR DESCRIPTION
This should really be a call to action, and not a mere description. Rename the page, and references to it to reflect this. Also change some answers in the FAQ that are about code contributions to point to the contributing page in GitHub directly.

I know this is probably creating a lot of 'empty noise' in the translations - most of which could probably be preempted with some clever updates in the input / output files. But I don't know Transifex well enough to know how to do this.