### PR TITLE
Update AppImage File Name Template to Match CICD Changes.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .

--- a/src/web/assetdownloader.py
+++ b/src/web/assetdownloader.py
@@ -96,7 +96,7 @@ def updateReleaseWebsite(release_id):
                 macosurl = url
             else:
                 missing += " macOS DMG,"
-            match = re.search(r"Subsurface-v(6.*)-CICD-release.AppImage", url)
+            match = re.search(r"Subsurface-(6.*)-CICD-release.AppImage", url)
             if match:
                 appimageurl = url
                 appimagename = match.group(0)

--- a/src/web/make-current.sh
+++ b/src/web/make-current.sh
@@ -26,7 +26,7 @@ cd $STATICPATH || croak "can't cd to $STATICPATH"
 for f in subsurface-6.0.${BUILDNR}-CICD-release-installer.exe \
         Subsurface-6.0.${BUILDNR}-CICD-release.dmg \
         Subsurface-mobile-6.0.${BUILDNR}-CICD-release.apk \
-        Subsurface-v6.0.${BUILDNR}-CICD-release.AppImage
+        Subsurface-6.0.${BUILDNR}-CICD-release.AppImage
 do
     wget "https://github.com/subsurface/nightly-builds/releases/download/v6.0.${BUILDNR}-CICD-release/$f"
 done

--- a/src/web/messages.pot
+++ b/src/web/messages.pot
@@ -365,7 +365,7 @@ msgstr ""
 #, python-format
 msgid ""
 "A generic AppImage is available. After you download this file, make it "
-"executable <code>chmod +x Subsurface-v%(version)s-CICD-"
+"executable <code>chmod +x Subsurface-%(version)s-CICD-"
 "release.AppImage</code>, and then simply run this file."
 msgstr ""
 

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -118,7 +118,7 @@ def utility_processor():
         if key == "landroid":
             return f"https://github.com/subsurface/nightly-builds/releases/download/v{env['lrelease'].value}-CICD-release/Subsurface-mobile-{env['lrelease'].value}-CICD-release.apk"
         if key == "lappimage":
-            return f"https://github.com/subsurface/nightly-builds/releases/download/v{env['lrelease'].value}-CICD-release/Subsurface-v{env['lrelease'].value}-CICD-release.AppImage"
+            return f"https://github.com/subsurface/nightly-builds/releases/download/v{env['lrelease'].value}-CICD-release/Subsurface-{env['lrelease'].value}-CICD-release.AppImage"
         if key == "cwindows":
             return f"https://subsurface-divelog.org/downloads/subsurface-{env['crelease'].value}-CICD-release-installer.exe"
         if key == "cmacos":

--- a/src/web/templates/latest-release.html
+++ b/src/web/templates/latest-release.html
@@ -128,7 +128,7 @@
           </h2>
         </div>
         <div class="col-12 col-md-6">
-          {{ _("A generic AppImage is available. After you download this file, make it executable <code>chmod +x Subsurface-v%(version)s-CICD-release.AppImage</code>, and then simply run this file.", version=get_env("lrelease")) }}
+          {{ _("A generic AppImage is available. After you download this file, make it executable <code>chmod +x Subsurface-%(version)s-CICD-release.AppImage</code>, and then simply run this file.", version=get_env("lrelease")) }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Update the file name template after the 'v' before the version number was removed to standardise the naming.