### PR TITLE
Update the name for the current AppImage.

### DIFF
--- a/src/web/server.py
+++ b/src/web/server.py
@@ -118,7 +118,7 @@ def utility_processor():
         if key == "landroid":
             return f"https://github.com/subsurface/nightly-builds/releases/download/v{env['lrelease'].value}-CICD-release/Subsurface-mobile-{env['lrelease'].value}-CICD-release.apk"
         if key == "lappimage":
-            return f"https://github.com/subsurface/nightly-builds/releases/download/v{env['lrelease'].value}-CICD-release/Subsurface-{env['lrelease'].value}-CICD-release.AppImage"
+            return f"https://github.com/subsurface/nightly-builds/releases/download/{env['lrelease'].value}-CICD-release/Subsurface-{env['lrelease'].value}-CICD-release.AppImage"
         if key == "cwindows":
             return f"https://subsurface-divelog.org/downloads/subsurface-{env['crelease'].value}-CICD-release-installer.exe"
         if key == "cmacos":
@@ -126,7 +126,7 @@ def utility_processor():
         if key == "candroid":
             return f"https://subsurface-divelog.org/downloads/Subsurface-mobile-{env['crelease'].value}-CICD-release.apk"
         if key == "cappimage":
-            return f"https://subsurface-divelog.org/downloads/Subsurface-v{env['crelease'].value}-CICD-release.AppImage"
+            return f"https://subsurface-divelog.org/downloads/Subsurface-{env['crelease'].value}-CICD-release.AppImage"
         if key == "lang":
             return f"/{get_locale()}"
         return ""

--- a/src/web/templates/current-release.html
+++ b/src/web/templates/current-release.html
@@ -129,7 +129,7 @@
           </h2>
         </div>
         <div class="col-12 col-md-6">
-          {{ _("A generic AppImage is available. After you download this file, make it executable <code>chmod +x Subsurface-v%(version)s-CICD-release.AppImage</code>, and then simply run this file.", version=get_env("crelease")) }}
+          {{ _("A generic AppImage is available. After you download this file, make it executable <code>chmod +x Subsurface-%(version)s-CICD-release.AppImage</code>, and then simply run this file.", version=get_env("crelease")) }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Drop the 'v' from the version that was dropped for consistency.