### PR TITLE
Add Link to the nightly-builds GitHub Releases page.

### DIFF
--- a/src/web/templates/latest-release.html
+++ b/src/web/templates/latest-release.html
@@ -14,8 +14,12 @@
       </h1>
       <h5>{{ get_env("lrelease_date") }}</h5>
       <p>
-        {{ _("The releases on this page are the latest builds from the Subsurface CICD (Continuous Integration, Continuous Delivery) system. While we don't expect them to be broken very often, they are generally released in order to facilitate testing, and as such may not have received a lot of testing, yet.") }}
+        {{ _("The releases on this page are the latest builds from the Subsurface CICD (Continuous Integration, Continuous Delivery) system. While we don't expect them to be broken very often, they may not have received a lot of testing yet, and may still be buggy.") }}
       </p>
+      <p>
+        {{ _("These installers, and previous versions of them, can also be found on the <a %(link)s>GitHub 'nightly-builds' Releases Page</a>.", link="href=https://github.com/subsurface/nightly-builds/releases") }}
+      </p>
+      <div class="row">
       <p>
         {{ _("The latest change-sets merged into this release are:") }}
       <ul>


### PR DESCRIPTION
Add a reference pointing users to the nightly-builds releases page on GitHub, so that they have a way of getting the latest build if the update of the latest builds page has not worked as expected.

![image](https://github.com/subsurface/new-website/assets/4742747/f89ec3cb-a0bf-431d-be8d-814a0800683a)
