### PR TITLE
Remove Pointers to the Developer Mailing List.

### DIFF
--- a/src/web/templates/bugtracker.html
+++ b/src/web/templates/bugtracker.html
@@ -12,7 +12,7 @@
     <div class="col-12">
       <h1 class="ssrf">{{_("Bug Tracker")}}</h1>
       <p>
-        {{ _("While we are happy to receive bug reports (and patches!) on our <a %(mailman)s>mailing list</a>, you can also open issues on our <a %(githubissue)s>main Subsurface repository on GitHub</a>.", mailman="href=http://lists.subsurface-divelog.org/cgi-bin/mailman/listinfo/subsurface", githubissue="href=https://github.com/Subsurface-divelog/subsurface/issues") }}
+        {{ _("If you find a bug in Subsurface, please check if there already ia an open issue for it in the <a %(githubissue)s>main Subsurface repository on GitHub</a>. If you can't find a bug report, please open a new issue. Issues are also the preferred way for feature requests.", githubissue="href=https://github.com/Subsurface-divelog/subsurface/issues") }}
       </p>
       <p>
         {{ _("The preferred language is English, but we’ll make an effort to answer questions in other languages as well (not everyone is comfortable posting in English…)") }}


### PR DESCRIPTION
Remove pointers to the developer mailing list from the README and CONTRIBUTING pages, as it is no longer possible to join it due to excessive brute force breakin attempts.