### PR TITLE
Add Instructions for Debian.

### DIFF
--- a/src/web/templates/current-release.html
+++ b/src/web/templates/current-release.html
@@ -90,6 +90,9 @@
           <p>
             {{ _("The Subsurface team is providing distribution packages for Ubuntu and Fedora as well as a Snap and a generic \"AppImage\" that should work on most other x86_64 Linux distributions.") }}
           </p>
+          <h4>{{ _("Debian") }}</h4>
+          <p>{{ _("There is a version of Subsurface for debian that is maintained by a community contributor.") }}</p>
+          <p>{{ _("For the initial setup follow the instructions on https://dfx.at/subsurface-debian/, and then install Subsurface with <code>sudo apt install subsurface</code>.") }}</p>
           <h4>{{ _("Ubuntu and compatible distros") }}</h4>
           <p>{{ _("To use these binaries in Ubuntu, simply add the Subsurface Daily Release PPA to your system:") }}</p>
           <pre><code>sudo add-apt-repository ppa:subsurface/subsurface-daily; sudo apt update</code></pre>

--- a/src/web/templates/latest-release.html
+++ b/src/web/templates/latest-release.html
@@ -97,6 +97,9 @@
           <p>
             {{ _("The Subsurface team is providing distribution packages for Ubuntu and Fedora as well as a Snap and a generic \"AppImage\" that should work on most other x86_64 Linux distributions.") }}
           </p>
+          <h4>{{ _("Debian") }}</h4>
+          <p>{{ _("There is a version of Subsurface for debian that is maintained by a community contributor.") }}</p>
+          <p>{{ _("For the initial setup follow the instructions on https://dfx.at/subsurface-debian/, and then install Subsurface with <code>sudo apt install subsurface-beta</code>.") }}</p>
           <h4>{{ _("Ubuntu and compatible distros") }}</h4>
           <p>{{ _("To use these binaries in Ubuntu, simply add the Subsurface Daily Release PPA to your system:") }}</p>
           <pre><code>sudo add-apt-repository ppa:subsurface/subsurface-daily; sudo apt update</code></pre>


### PR DESCRIPTION
Add instructions for installing Subsurface in Debian from the packages
provided in https://dfx.at/subsurface-debian/.
This is intentionally before the instructions for Ubuntu, as 'Ubuntu and
compatible distros' might be misleading for Debian users, and PPAs
aren't fully supported in Debian, see
https://github.com/subsurface/subsurface/issues/4547#issuecomment-3008667127.

FYI: @dfxdj

Signed-off-by: Michael Keller <github@ike.ch>
